### PR TITLE
fix: add tn-fzf to package.json bin for global installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Command-line interface for TaskNotes with interactive mode and real-time NLP preview",
   "main": "bin/tn",
   "bin": {
-    "tn": "./bin/tn"
+    "tn": "./bin/tn",
+    "tn-fzf": "./bin/tn-fzf"
   },
   "scripts": {
     "start": "node bin/tn",


### PR DESCRIPTION
The tn-fzf script was present in bin/ but not registered in package.json, so it wasn't being linked globally when running 'npm link'.

This fix adds tn-fzf to the bin section so users get both commands:
- tn: Main CLI interface
- tn-fzf: Interactive fzf-based task browser