### PR TITLE
fix: remove redundant # prefix from tag display

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ function formatTask(task, options = {}) {
     
     // Tags
     if (task.tags && task.tags.length > 0) {
-      output += `  ${colors.dim('Tags:')} ${task.tags.map(tag => colors.highlight(`#${tag}`)).join(' ')}\n`;
+      output += `  ${colors.dim('Tags:')} ${task.tags.map(tag => colors.highlight(tag)).join(' ')}\n`;
     }
     
     // Contexts
@@ -125,7 +125,7 @@ function formatPreview(parsed) {
   
   // Tags
   if (parsed.tags && parsed.tags.length > 0) {
-    output += `${colors.highlight('Tags:')} ${parsed.tags.map(tag => colors.info(`#${tag}`)).join(' ')}\n`;
+    output += `${colors.highlight('Tags:')} ${parsed.tags.map(tag => colors.info(tag)).join(' ')}\n`;
   }
   
   // Contexts


### PR DESCRIPTION
## Summary

Tags display as `##task` instead of `#task` because the CLI prepends `#` to tags that already have `#` from the API.

## Root cause

The TaskNotes HTTP API returns tags from Obsidian's metadata cache, which always prepends `#` to frontmatter tag values (e.g. `tags: [task]` in YAML becomes `["#task"]` in the cache/API response).

`lib/utils.js` unconditionally prepends another `#` for display:

```js
// Line 45 - task list display
task.tags.map(tag => colors.highlight(`#${tag}`))
// "#" + "#task" = "##task"

// Line 128 - parsed task display
parsed.tags.map(tag => colors.info(`#${tag}`))
```

## Fix

Remove the redundant `#` prefix. The API value already includes it:

```js
task.tags.map(tag => colors.highlight(tag))
parsed.tags.map(tag => colors.info(tag))
```

## Reproduction

```bash
# Create a task
tn create "Test task today #planning 15m"

# List tasks -- tags show ##task ##planning
tn list

# Check what the API actually returns
curl -s http://localhost:8080/api/tasks | python3 -c "
import sys, json
data = json.load(sys.stdin)
print(data['data']['tasks'][0]['tags'])
"
# Output: ['#task', '#planning']  -- already has #
```

## After fix

```
Tags: #task #planning
```